### PR TITLE
removed call to .sh file to call native launcher instead

### DIFF
--- a/src/fttb/cmds/use.py
+++ b/src/fttb/cmds/use.py
@@ -50,7 +50,7 @@ def generate_entry(ide, ide_code, version, config_fttb):
     )
     entry = entry.replace(
         "{exec}",
-        f"{config_fttb['install_path']}/{ide_code}-{version}/bin/{ide}.sh %U"
+        f"{config_fttb['install_path']}/{ide_code}-{version}/bin/{ide} %U"
     )
     entry = entry.replace(
         "{icon}",
@@ -63,7 +63,7 @@ def generate_entry(ide, ide_code, version, config_fttb):
         os.remove(f"{config_fttb['bin_path']}/{ide}")
     except FileNotFoundError:
         pass
-    os.symlink(f"{config_fttb['install_path']}/{ide_code}-{version}/bin/{ide}.sh", f"{config_fttb['bin_path']}/{ide}")
+    os.symlink(f"{config_fttb['install_path']}/{ide_code}-{version}/bin/{ide}", f"{config_fttb['bin_path']}/{ide}")
 
 
 def use_cmd(args, config_fttb):


### PR DESCRIPTION
Launching the IDE via the command line after installing it using the "use" command was throwing a warning that the ide was launch using the shell script and recommending launching it using the native binary : https://youtrack.jetbrains.com/articles/SUPPORT-A-56/How-to-handle-Switch-to-a-native-launcher-notification

This PR update the installation process of the "use" command to create an entry using the native bin instead of the .sh file.